### PR TITLE
Adds Statamic\Eloquent\Events\TypeRequested for use in EntryRepository

### DIFF
--- a/src/Entries/EntryRepository.php
+++ b/src/Entries/EntryRepository.php
@@ -6,6 +6,7 @@ use Statamic\Contracts\Entries\Entry as EntryContract;
 use Statamic\Contracts\Entries\QueryBuilder;
 use Statamic\Eloquent\Jobs\UpdateCollectionEntryOrder;
 use Statamic\Eloquent\Jobs\UpdateCollectionEntryParent;
+use Statamic\Entries\EntryCollection;
 use Statamic\Facades\Blink;
 use Statamic\Stache\Repositories\EntryRepository as StacheRepository;
 
@@ -49,6 +50,30 @@ class EntryRepository extends StacheRepository
         }
 
         return $this->substitutionsById[$item->id()] ?? $item;
+    }
+
+    public function findByIds($ids): EntryCollection
+    {
+        $cached = collect($ids)->flip()->map(fn ($_, $id) => Blink::get("eloquent-entry-{$id}"));
+        $missingIds = $cached->reject()->keys();
+
+        $missingById = $this->query()
+            ->whereIn('id', $missingIds)
+            ->get()
+            ->keyBy->id();
+
+        $missingById->each(function ($entry, $id) {
+            Blink::put("eloquent-entry-{$id}", $entry);
+        });
+
+        $items = $cached
+            ->map(fn ($entry, $id) => $entry ?? $missingById->get($id))
+            ->filter()
+            ->values();
+
+        $this->applySubstitutions($items);
+
+        return EntryCollection::make($items);
     }
 
     public function save($entry)

--- a/src/Entries/EntryRepository.php
+++ b/src/Entries/EntryRepository.php
@@ -4,6 +4,7 @@ namespace Statamic\Eloquent\Entries;
 
 use Statamic\Contracts\Entries\Entry as EntryContract;
 use Statamic\Contracts\Entries\QueryBuilder;
+use Statamic\Eloquent\Events\TypeRetrieved;
 use Statamic\Eloquent\Jobs\UpdateCollectionEntryOrder;
 use Statamic\Eloquent\Jobs\UpdateCollectionEntryParent;
 use Statamic\Entries\EntryCollection;
@@ -33,7 +34,9 @@ class EntryRepository extends StacheRepository
             return null;
         }
 
-        return $this->substitutionsById[$item->id()] ?? $item;
+        return tap($this->substitutionsById[$item->id()] ?? $item, function ($entry) {
+            TypeRetrieved::dispatch($entry);
+        });
     }
 
     public function findByUri(string $uri, ?string $site = null): ?EntryContract
@@ -49,7 +52,9 @@ class EntryRepository extends StacheRepository
             return null;
         }
 
-        return $this->substitutionsById[$item->id()] ?? $item;
+        return tap($this->substitutionsById[$item->id()] ?? $item, function ($entry) {
+            TypeRetrieved::dispatch($entry);
+        });
     }
 
     public function findByIds($ids): EntryCollection
@@ -71,9 +76,17 @@ class EntryRepository extends StacheRepository
             ->filter()
             ->values();
 
-        $this->applySubstitutions($items);
+        $substituted = $this->applySubstitutions($items);
 
-        return EntryCollection::make($items);
+        return EntryCollection::make($substituted)->each(function ($entry) {
+            TypeRetrieved::dispatch($entry);
+        });
+    }
+
+    public function storeInCache($entry)
+    {
+        Blink::put("eloquent-entry-{$entry->id()}", $entry);
+        Blink::put("eloquent-entry-{$entry->uri()}", $entry);
     }
 
     public function save($entry)
@@ -83,8 +96,7 @@ class EntryRepository extends StacheRepository
 
         $entry->model($model->fresh());
 
-        Blink::put("eloquent-entry-{$entry->id()}", $entry);
-        Blink::put("eloquent-entry-{$entry->uri()}", $entry);
+        $this->storeInCache($entry);
     }
 
     public function delete($entry)

--- a/src/Events/TypeRetrieved.php
+++ b/src/Events/TypeRetrieved.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Statamic\Eloquent\Events;
+
+use Statamic\Events\Event;
+
+class TypeRetrieved extends Event
+{
+    /**
+     * Fired when a type if requested through a Repository and found, either in
+     * the cache or loaded from the database. Currently, only the implemented
+     * by the EntryRepository.
+     *
+     * @param  \Statamic\Contracts\Entry\Entry  $target
+     */
+    public function __construct(public $target) {}
+}

--- a/tests/Entries/EntryRepositoryTest.php
+++ b/tests/Entries/EntryRepositoryTest.php
@@ -4,11 +4,14 @@ namespace Tests\Entries;
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Event;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Statamic\Eloquent\Entries\Entry;
 use Statamic\Eloquent\Entries\EntryModel;
 use Statamic\Eloquent\Entries\EntryRepository;
+use Statamic\Entries\EntryCollection;
 use Statamic\Events\CollectionTreeSaved;
+use Statamic\Facades\Blink;
 use Statamic\Facades\Collection;
 use Statamic\Stache\Stache;
 use Tests\TestCase;
@@ -233,5 +236,74 @@ class EntryRepositoryTest extends TestCase
             3 => 4,
             4 => null,
         ], EntryModel::all()->mapWithKeys(fn ($e) => [$e->id => $e->data['parent'] ?? null])->all());
+    }
+
+    #[Test, Group('EntryRepository#findByIds')]
+    public function it_gets_entries_by_ids()
+    {
+        $collection = Collection::make('pages')->routes('{slug}')->save();
+        $expected = collect([
+            (new Entry)->collection($collection)->slug('foo'),
+            (new Entry)->collection($collection)->slug('bar'),
+        ])->each->save();
+
+        $actual = (new EntryRepository(new Stache))->findByIds($expected->map->id());
+
+        $this->assertInstanceOf(EntryCollection::class, $actual);
+        $this->assertEquals($expected->map->id()->all(), $actual->map->id()->all());
+    }
+
+    #[Test, Group('EntryRepository#findByIds')]
+    public function it_loads_entries_from_database_given_partial_cache_when_finding_by_ids()
+    {
+        $collection = Collection::make('pages')->routes('{slug}')->save();
+        $expected = collect([
+            (new Entry)->collection($collection)->slug('foo'),
+            (new Entry)->collection($collection)->slug('bar'),
+        ]);
+
+        $expected->first()->save();
+        Blink::flush();
+        $expected->last()->save();
+
+        $actual = (new EntryRepository(new Stache))->findByIds($expected->map->id());
+
+        $this->assertNotNull($expected->first()->id());
+        $this->assertNotSame($expected->first(), $actual->first());
+        $this->assertEquals($expected->first()->id(), $actual->first()->id());
+        $this->assertNotNull($actual->last());
+        $this->assertSame($expected->last(), $actual->last());
+    }
+
+    #[Test, Group('EntryRepository#findByIds')]
+    public function it_returns_entries_in_exact_order_when_finding_by_ids()
+    {
+        $collection = Collection::make('pages')->routes('{slug}')->save();
+        $entries = collect([
+            (new Entry)->collection($collection)->slug('foo'),
+            (new Entry)->collection($collection)->slug('bar'),
+            (new Entry)->collection($collection)->slug('baz'),
+        ])->each->save();
+
+        Blink::flush();
+
+        $expected = collect([2, 0, 1])->map(fn ($index) => $entries[$index]->id())->all();
+        $actual = (new EntryRepository(new Stache))->findByIds($expected);
+
+        $this->assertEquals($expected, $actual->map->id()->all());
+    }
+
+    #[Test, Group('EntryRepository#findByIds')]
+    public function it_skips_missing_entires_when_finding_by_ids()
+    {
+        $collection = Collection::make('pages')->routes('{slug}')->save();
+        $expected = tap((new Entry)->collection($collection)->slug('foo'))->save();
+
+        $actual = (new EntryRepository(new Stache))->findByIds([
+            $expected->id(),
+            'missing',
+        ]);
+
+        $this->assertEquals([$expected->id()], $actual->map->id()->all());
     }
 }

--- a/tests/Entries/EntryRepositoryTest.php
+++ b/tests/Entries/EntryRepositoryTest.php
@@ -4,11 +4,13 @@ namespace Tests\Entries;
 
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Event;
+use Mockery;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\Attributes\Test;
 use Statamic\Eloquent\Entries\Entry;
 use Statamic\Eloquent\Entries\EntryModel;
 use Statamic\Eloquent\Entries\EntryRepository;
+use Statamic\Eloquent\Events\TypeRetrieved;
 use Statamic\Entries\EntryCollection;
 use Statamic\Events\CollectionTreeSaved;
 use Statamic\Facades\Blink;
@@ -305,5 +307,85 @@ class EntryRepositoryTest extends TestCase
         ]);
 
         $this->assertEquals([$expected->id()], $actual->map->id()->all());
+    }
+
+    #[Test, Group('TypeRetrieved')]
+    public function it_fires_type_retrieved_event_entry_when_found()
+    {
+        Event::fake();
+        $collection = Collection::make('pages')->routes('{slug}')->save();
+        $expected = tap((new Entry)->collection($collection)->slug('foo'))->save();
+
+        (new EntryRepository(new Stache))->find($expected->id());
+
+        Event::assertDispatched(TypeRetrieved::class, function (TypeRetrieved $event) use ($expected) {
+            $this->assertSame($expected, $event->target);
+
+            return true;
+        });
+    }
+
+    #[Test, Group('TypeRetrieved')]
+    public function it_fires_type_retrieved_event_when_not_already_in_cache()
+    {
+        Event::fake();
+        $collection = Collection::make('pages')->routes('{slug}')->save();
+        $expected = tap((new Entry)->collection($collection)->slug('foo'))->save();
+
+        Blink::flush();
+        (new EntryRepository(new Stache))->find($expected->id());
+
+        Event::assertDispatched(TypeRetrieved::class, function (TypeRetrieved $event) use ($expected) {
+            $this->assertNotSame($expected, $event->target);
+            $this->assertEquals($expected->id(), $event->target->id());
+
+            return true;
+        });
+    }
+
+    #[Test, Group('TypeRetrieved')]
+    public function it_fires_type_retrieved_event_when_entry_found_by_ids()
+    {
+        Event::fake();
+        $collection = Collection::make('pages')->routes('{slug}')->save();
+        $expected = collect([
+            (new Entry)->collection($collection)->slug('foo'),
+            (new Entry)->collection($collection)->slug('bar'),
+            (new Entry)->collection($collection)->slug('baz'),
+        ])->each->save();
+
+        (new EntryRepository(new Stache))->findByIds($expected->map->id());
+
+        Event::assertDispatchedTimes(TypeRetrieved::class, 3);
+    }
+
+    #[Test, Group('TypeRetrieved')]
+    public function it_fires_type_retrieved_only_for_found_entries_when_finding_by_ids()
+    {
+        Event::fake();
+        $collection = Collection::make('pages')->routes('{slug}')->save();
+        $expected = tap((new Entry)->collection($collection)->slug('foo'))->save();
+
+        (new EntryRepository(new Stache))->findByIds([
+            $expected->id(),
+            'missing',
+        ]);
+
+        Event::assertDispatchedTimes(TypeRetrieved::class, 1);
+    }
+
+    #[Test, Group('TypeRetrieved')]
+    public function it_loads_from_cache_once_stored()
+    {
+        $collection = Collection::make('pages')->routes('{slug}')->save();
+        $expected = (new Entry)->id(1)->collection($collection)->slug('foo');
+
+        $builder = Mockery::mock(\Statamic\Eloquent\Entries\EntryQueryBuilder::class);
+        $builder->shouldNotReceive('where');
+
+        $repo = (new EntryRepository(new Stache));
+        $repo->storeInCache($expected);
+
+        $this->assertSame($expected, $repo->find($expected->id()));
     }
 }


### PR DESCRIPTION
This PR adds a new `TypeRetrieved` event, intended for repositories to emit when types (e.g. entries) are loaded by identifier.

```php
<?php

namespace Statamic\Eloquent\Events;

use Statamic\Events\Event;

class TypeRetrieved extends Event
{
    /**
     * Fired when a type if requested through a Repository and found, either in
     * the cache or loaded from the database. Currently, only the implemented
     * by the EntryRepository.
     *
     * @param  \Statamic\Contracts\Entry\Entry  $target
     */
    public function __construct(public $target) {}
}
```

It builds off another [open PR](https://github.com/statamic/eloquent-driver/pull/417) at the moment.

```php
(new Entry)->id(1)->slug('home');
(new Entry)->id(2)->slug('about');

\Statamic\Facades\Entry::find(1); // Fires
\Statamic\Facades\Entry::find(10); // Doesn't fire
\Statamic\Facades\Entry::findByUri('/about'); // Fires
```

Notably, this is does not fire via the methods that are indirectly loading entires. I.e. `->whereCollection()` as the entries are not being found by identifier.

This is part of a wider piece of work I've start to add a fairly large reduction in DB queries to the `statamic/eloquent-driver`. The principal is to route as many modules of the system as possible through the repositories so that they may emitting this event.

In my own projects, I rebind all the repositories via the container to do this, but it would be useful if the repositories did it themselves - hence the PR.

## Utility and performance gain

Once in emitting, you can do an interesting optimisation of `statamic.web` routes. Rather than loading each entry one by one whilst Statamic Values are being augmented, instead, at end of each request you can store into the cache a list of IDs what were requested. Then, when next rendering the page, eager load them into the blink cache.

**To be clear, this is not simply caching the entries, but rather just their IDs. We gain the luxury of not having to think about cache invalidation.**

The rationale is that its typically cheaper to do one DB query for 20 entries than it is to do 20 DB queries.

There are some edge cases:

 - Two many entries loaded. Following a publishing of an entry by a content editor, in between frontend requests, one of the entries are loaded from the database but isn't use.
 - Not enough entries loaded. Again, the content editor makes some changes in between requests, this time removing a link to an entry. The repository will not find the entry in the blink cache and fallback to a DB query to retrieve it.
 
 In both cases the type usage cache isn't up to date, but only for one request. As soon as the page renders again, the exact type usage will be save. In both cases there is still a very high likelyhood that the number of DB queries will be dramatically reduced.

Pseudo code for simplicity below:

```php
class AppServiceProvider extends ServiceProvider
{
    public function boot()
    {
        $this->app->singleton(TypeUsage::class);
        Route::prependMiddlewareToGroup('statamic.web', RecordTypeUsage::class);
        Event::listen(TypeRetrieved::class, TypeUsage::class);
    }
}

class RecordTypeUsage
{
    public function __construct(public TypeUsage $usage)
    {
    }

    public function handle(Request $request, Closure $next)
    {
        $this->usage->load($request->path());
        $response = $next($request);
        $this->usage->save($request->path());

        return $response;
    }
}

class TypeUsage
{
    protected array $cached = [];
    protected array $actual = [];

    public function load(string $path)
    {
        $usage = Cache::get("type-usage::{$path}") ?? [];

        $items = Entry::query()->whereIn('id', $usage ?? [])->get();
        $items->each(fn ($entry) => $this->entries->storeInCache($entry));
    }

    public function save(string $path)
    {
        $actual = collect($this->actual)->keys()->sort()->all();
        $cached = collect($this->cached)->keys()->sort()->all();

        // No DB write needed if the current usage is the same as last time.
        if ($actual === $cached) {
            return;
        }

        Cache::put("type-usage::{$path}");
    }
}
```

_Note: the example above is only for entries, but could be expanded to the other types in Statamic, e.g. assets, terms etc._

## Intention to implement further

Should this is something that could be merged, I'd be happy to extend this functionality to all the repositories that use `find` and `findBy`.
